### PR TITLE
Move function arguments onto a single line

### DIFF
--- a/Arduboy2/Arduboy2.cpp
+++ b/Arduboy2/Arduboy2.cpp
@@ -401,8 +401,7 @@ void Arduboy2Base::drawCircle(int16_t x0, int16_t y0, uint8_t r, uint8_t color)
   }
 }
 
-void Arduboy2Base::drawCircleHelper
-(int16_t x0, int16_t y0, uint8_t r, uint8_t corners, uint8_t color)
+void Arduboy2Base::drawCircleHelper(int16_t x0, int16_t y0, uint8_t r, uint8_t corners, uint8_t color)
 {
   int16_t f = 1 - r;
   int16_t ddF_x = 1;
@@ -452,9 +451,7 @@ void Arduboy2Base::fillCircle(int16_t x0, int16_t y0, uint8_t r, uint8_t color)
   fillCircleHelper(x0, y0, r, 3, 0, color);
 }
 
-void Arduboy2Base::fillCircleHelper
-(int16_t x0, int16_t y0, uint8_t r, uint8_t sides, int16_t delta,
- uint8_t color)
+void Arduboy2Base::fillCircleHelper(int16_t x0, int16_t y0, uint8_t r, uint8_t sides, int16_t delta, uint8_t color)
 {
   int16_t f = 1 - r;
   int16_t ddF_x = 1;
@@ -489,8 +486,7 @@ void Arduboy2Base::fillCircleHelper
   }
 }
 
-void Arduboy2Base::drawLine
-(int16_t x0, int16_t y0, int16_t x1, int16_t y1, uint8_t color)
+void Arduboy2Base::drawLine(int16_t x0, int16_t y0, int16_t x1, int16_t y1, uint8_t color)
 {
   // bresenham's algorithm - thx wikpedia
   bool steep = abs(y1 - y0) > abs(x1 - x0);
@@ -540,8 +536,7 @@ void Arduboy2Base::drawLine
   }
 }
 
-void Arduboy2Base::drawRect
-(int16_t x, int16_t y, uint8_t w, uint8_t h, uint8_t color)
+void Arduboy2Base::drawRect(int16_t x, int16_t y, uint8_t w, uint8_t h, uint8_t color)
 {
   drawFastHLine(x, y, w, color);
   drawFastHLine(x, y+h-1, w, color);
@@ -549,8 +544,7 @@ void Arduboy2Base::drawRect
   drawFastVLine(x+w-1, y, h, color);
 }
 
-void Arduboy2Base::drawFastVLine
-(int16_t x, int16_t y, uint8_t h, uint8_t color)
+void Arduboy2Base::drawFastVLine(int16_t x, int16_t y, uint8_t h, uint8_t color)
 {
   int end = y+h;
   for (int a = max(0,y); a < min(end,HEIGHT); a++)
@@ -559,8 +553,7 @@ void Arduboy2Base::drawFastVLine
   }
 }
 
-void Arduboy2Base::drawFastHLine
-(int16_t x, int16_t y, uint8_t w, uint8_t color)
+void Arduboy2Base::drawFastHLine(int16_t x, int16_t y, uint8_t w, uint8_t color)
 {
   int16_t xEnd; // last x point + 1
 
@@ -610,8 +603,7 @@ void Arduboy2Base::drawFastHLine
   }
 }
 
-void Arduboy2Base::fillRect
-(int16_t x, int16_t y, uint8_t w, uint8_t h, uint8_t color)
+void Arduboy2Base::fillRect(int16_t x, int16_t y, uint8_t w, uint8_t h, uint8_t color)
 {
   // stupidest version - update in subclasses if desired!
   for (int16_t i=x; i<x+w; i++)
@@ -668,8 +660,7 @@ void Arduboy2Base::fillScreen(uint8_t color)
   );
 }
 
-void Arduboy2Base::drawRoundRect
-(int16_t x, int16_t y, uint8_t w, uint8_t h, uint8_t r, uint8_t color)
+void Arduboy2Base::drawRoundRect(int16_t x, int16_t y, uint8_t w, uint8_t h, uint8_t r, uint8_t color)
 {
   // smarter version
   drawFastHLine(x+r, y, w-2*r, color); // Top
@@ -683,8 +674,7 @@ void Arduboy2Base::drawRoundRect
   drawCircleHelper(x+r, y+h-r-1, r, 8, color);
 }
 
-void Arduboy2Base::fillRoundRect
-(int16_t x, int16_t y, uint8_t w, uint8_t h, uint8_t r, uint8_t color)
+void Arduboy2Base::fillRoundRect(int16_t x, int16_t y, uint8_t w, uint8_t h, uint8_t r, uint8_t color)
 {
   // smarter version
   fillRect(x+r, y, w-2*r, h, color);
@@ -694,16 +684,14 @@ void Arduboy2Base::fillRoundRect
   fillCircleHelper(x+r, y+r, r, 2, h-2*r-1, color);
 }
 
-void Arduboy2Base::drawTriangle
-(int16_t x0, int16_t y0, int16_t x1, int16_t y1, int16_t x2, int16_t y2, uint8_t color)
+void Arduboy2Base::drawTriangle(int16_t x0, int16_t y0, int16_t x1, int16_t y1, int16_t x2, int16_t y2, uint8_t color)
 {
   drawLine(x0, y0, x1, y1, color);
   drawLine(x1, y1, x2, y2, color);
   drawLine(x2, y2, x0, y0, color);
 }
 
-void Arduboy2Base::fillTriangle
-(int16_t x0, int16_t y0, int16_t x1, int16_t y1, int16_t x2, int16_t y2, uint8_t color)
+void Arduboy2Base::fillTriangle(int16_t x0, int16_t y0, int16_t x1, int16_t y1, int16_t x2, int16_t y2, uint8_t color)
 {
 
   int16_t a, b, y, last;
@@ -805,9 +793,7 @@ void Arduboy2Base::fillTriangle
   }
 }
 
-void Arduboy2Base::drawBitmap
-(int16_t x, int16_t y, const uint8_t *bitmap, uint8_t w, uint8_t h,
- uint8_t color)
+void Arduboy2Base::drawBitmap(int16_t x, int16_t y, const uint8_t *bitmap, uint8_t w, uint8_t h, uint8_t color)
 {
   // no need to draw at all if we're offscreen
   if (x+w < 0 || x > WIDTH-1 || y+h < 0 || y > HEIGHT-1)
@@ -851,8 +837,7 @@ void Arduboy2Base::drawBitmap
 }
 
 
-void Arduboy2Base::drawSlowXYBitmap
-(int16_t x, int16_t y, const uint8_t *bitmap, uint8_t w, uint8_t h, uint8_t color)
+void Arduboy2Base::drawSlowXYBitmap(int16_t x, int16_t y, const uint8_t *bitmap, uint8_t w, uint8_t h, uint8_t color)
 {
   // no need to draw at all of we're offscreen
   if (x+w < 0 || x > WIDTH-1 || y+h < 0 || y > HEIGHT-1)
@@ -1263,8 +1248,7 @@ size_t Arduboy2::write(uint8_t c)
   return 1;
 }
 
-void Arduboy2::drawChar
-  (int16_t x, int16_t y, unsigned char c, uint8_t color, uint8_t bg, uint8_t size)
+void Arduboy2::drawChar(int16_t x, int16_t y, unsigned char c, uint8_t color, uint8_t bg, uint8_t size)
 {
   uint8_t line;
   bool draw_background = bg != color;

--- a/Arduboy2/Sprites.cpp
+++ b/Arduboy2/Sprites.cpp
@@ -6,8 +6,7 @@
 
 #include "Sprites.h"
 
-void Sprites::drawExternalMask(int16_t x, int16_t y, const uint8_t *bitmap,
-                               const uint8_t *mask, uint8_t frame, uint8_t mask_frame)
+void Sprites::drawExternalMask(int16_t x, int16_t y, const uint8_t *bitmap, const uint8_t *mask, uint8_t frame, uint8_t mask_frame)
 {
   draw(x, y, bitmap, frame, mask, mask_frame, SPRITE_MASKED);
 }
@@ -34,10 +33,7 @@ void Sprites::drawPlusMask(int16_t x, int16_t y, const uint8_t *bitmap, uint8_t 
 
 
 //common functions
-void Sprites::draw(int16_t x, int16_t y,
-                   const uint8_t *bitmap, uint8_t frame,
-                   const uint8_t *mask, uint8_t sprite_frame,
-                   uint8_t drawMode)
+void Sprites::draw(int16_t x, int16_t y, const uint8_t *bitmap, uint8_t frame, const uint8_t *mask, uint8_t sprite_frame, uint8_t drawMode)
 {
   unsigned int frame_offset;
 
@@ -67,9 +63,7 @@ void Sprites::draw(int16_t x, int16_t y,
   drawBitmap(x, y, bitmap, mask, width, height, drawMode);
 }
 
-void Sprites::drawBitmap(int16_t x, int16_t y,
-                         const uint8_t *bitmap, const uint8_t *mask,
-                         uint8_t w, uint8_t h, uint8_t draw_mode)
+void Sprites::drawBitmap(int16_t x, int16_t y, const uint8_t *bitmap, const uint8_t *mask, uint8_t w, uint8_t h, uint8_t draw_mode)
 {
   // no need to draw at all of we're offscreen
   if (x + w <= 0 || x > WIDTH - 1 || y + h <= 0 || y > HEIGHT - 1)

--- a/Arduboy2/Sprites.h
+++ b/Arduboy2/Sprites.h
@@ -109,8 +109,7 @@ class Sprites
      *     --#--  #####  #####   --#--
      *     -----  -###-  #####   #---#
      */
-    static void drawExternalMask(int16_t x, int16_t y, const uint8_t *bitmap,
-                                 const uint8_t *mask, uint8_t frame, uint8_t mask_frame);
+    static void drawExternalMask(int16_t x, int16_t y, const uint8_t *bitmap, const uint8_t *mask, uint8_t frame, uint8_t mask_frame);
 
     /** \brief
      * Draw a sprite using an array containing both image and mask values.
@@ -243,15 +242,10 @@ class Sprites
     // Master function. Needs to be abstracted into separate function for
     // every render type.
     // (Not officially part of the API)
-    static void draw(int16_t x, int16_t y,
-                     const uint8_t *bitmap, uint8_t frame,
-                     const uint8_t *mask, uint8_t sprite_frame,
-                     uint8_t drawMode);
+    static void draw(int16_t x, int16_t y, const uint8_t *bitmap, uint8_t frame, const uint8_t *mask, uint8_t sprite_frame, uint8_t drawMode);
 
     // (Not officially part of the API)
-    static void drawBitmap(int16_t x, int16_t y,
-                           const uint8_t *bitmap, const uint8_t *mask,
-                           uint8_t w, uint8_t h, uint8_t draw_mode);
+    static void drawBitmap(int16_t x, int16_t y, const uint8_t *bitmap, const uint8_t *mask, uint8_t w, uint8_t h, uint8_t draw_mode);
 };
 
 #endif

--- a/Arduboy2/SpritesB.cpp
+++ b/Arduboy2/SpritesB.cpp
@@ -7,8 +7,7 @@
 
 #include "SpritesB.h"
 
-void SpritesB::drawExternalMask(int16_t x, int16_t y, const uint8_t *bitmap,
-                               const uint8_t *mask, uint8_t frame, uint8_t mask_frame)
+void SpritesB::drawExternalMask(int16_t x, int16_t y, const uint8_t *bitmap, const uint8_t *mask, uint8_t frame, uint8_t mask_frame)
 {
   draw(x, y, bitmap, frame, mask, mask_frame, SPRITE_MASKED);
 }
@@ -35,10 +34,7 @@ void SpritesB::drawPlusMask(int16_t x, int16_t y, const uint8_t *bitmap, uint8_t
 
 
 //common functions
-void SpritesB::draw(int16_t x, int16_t y,
-                   const uint8_t *bitmap, uint8_t frame,
-                   const uint8_t *mask, uint8_t sprite_frame,
-                   uint8_t drawMode)
+void SpritesB::draw(int16_t x, int16_t y, const uint8_t *bitmap, uint8_t frame, const uint8_t *mask, uint8_t sprite_frame, uint8_t drawMode)
 {
   unsigned int frame_offset;
 
@@ -68,9 +64,7 @@ void SpritesB::draw(int16_t x, int16_t y,
   drawBitmap(x, y, bitmap, mask, width, height, drawMode);
 }
 
-void SpritesB::drawBitmap(int16_t x, int16_t y,
-                         const uint8_t *bitmap, const uint8_t *mask,
-                         uint8_t w, uint8_t h, uint8_t draw_mode)
+void SpritesB::drawBitmap(int16_t x, int16_t y, const uint8_t *bitmap, const uint8_t *mask, uint8_t w, uint8_t h, uint8_t draw_mode)
 {
   // no need to draw at all of we're offscreen
   if (x + w <= 0 || x > WIDTH - 1 || y + h <= 0 || y > HEIGHT - 1)

--- a/Arduboy2/SpritesB.h
+++ b/Arduboy2/SpritesB.h
@@ -52,8 +52,7 @@ class SpritesB
      *
      * \see Sprites::drawExternalMask()
      */
-    static void drawExternalMask(int16_t x, int16_t y, const uint8_t *bitmap,
-                                 const uint8_t *mask, uint8_t frame, uint8_t mask_frame);
+    static void drawExternalMask(int16_t x, int16_t y, const uint8_t *bitmap, const uint8_t *mask, uint8_t frame, uint8_t mask_frame);
 
     /** \brief
      * Draw a sprite using an array containing both image and mask values.
@@ -102,15 +101,10 @@ class SpritesB
     // Master function. Needs to be abstracted into separate function for
     // every render type.
     // (Not officially part of the API)
-    static void draw(int16_t x, int16_t y,
-                     const uint8_t *bitmap, uint8_t frame,
-                     const uint8_t *mask, uint8_t sprite_frame,
-                     uint8_t drawMode);
+    static void draw(int16_t x, int16_t y, const uint8_t *bitmap, uint8_t frame, const uint8_t *mask, uint8_t sprite_frame, uint8_t drawMode);
 
     // (Not officially part of the API)
-    static void drawBitmap(int16_t x, int16_t y,
-                           const uint8_t *bitmap, const uint8_t *mask,
-                           uint8_t w, uint8_t h, uint8_t draw_mode);
+    static void drawBitmap(int16_t x, int16_t y, const uint8_t *bitmap, const uint8_t *mask, uint8_t w, uint8_t h, uint8_t draw_mode);
 };
 
 #endif


### PR DESCRIPTION
Ensures that the arguments of all function declarations and definition stay on a single line.