### PR TITLE
Reformat increments and decrements

### DIFF
--- a/Arduboy2/Arduboy2.cpp
+++ b/Arduboy2/Arduboy2.cpp
@@ -183,7 +183,7 @@ void Arduboy2Base::bootLogoShell(void (*drawLogo)(int16_t))
 	if (showLEDs)
 		digitalWriteRGB(RED_LED, RGB_ON);
 
-	for (int16_t y = -16; y <= 24; y++)
+	for (int16_t y = -16; y <= 24; ++y)
 	{
 		if (pressed(RIGHT_BUTTON))
 		{
@@ -270,7 +270,8 @@ bool Arduboy2Base::nextFrame()
 	{
 		// Only idle if at least a full millisecond remains, since idle() may
 		// sleep the processor until the next millisecond timer interrupt.
-		if (++frameDurationMs < eachFrameMillis)
+		++frameDurationMs;
+		if (frameDurationMs < eachFrameMillis)
 			idle();
 
 		return false;
@@ -279,7 +280,7 @@ bool Arduboy2Base::nextFrame()
 	// pre-render
 	justRendered = true;
 	thisFrameStart = now;
-	frameCount++;
+	++frameCount;
 
 	return true;
 }
@@ -417,12 +418,12 @@ void Arduboy2Base::drawCircle(int16_t x0, int16_t y0, uint8_t r, uint8_t color)
 	{
 		if (f >= 0)
 		{
-			y--;
+			--y;
 			ddF_y += 2;
 			f += ddF_y;
 		}
 
-		x++;
+		++x;
 		ddF_x += 2;
 		f += ddF_x;
 
@@ -449,12 +450,12 @@ void Arduboy2Base::drawCircleHelper(int16_t x0, int16_t y0, uint8_t r, uint8_t c
 	{
 		if (f >= 0)
 		{
-			y--;
+			--y;
 			ddF_y += 2;
 			f += ddF_y;
 		}
 
-		x++;
+		++x;
 		ddF_x += 2;
 		f += ddF_x;
 
@@ -503,12 +504,12 @@ void Arduboy2Base::fillCircleHelper(int16_t x0, int16_t y0, uint8_t r, uint8_t s
 	{
 		if (f >= 0)
 		{
-			y--;
+			--y;
 			ddF_y += 2;
 			f += ddF_y;
 		}
 
-		x++;
+		++x;
 		ddF_x += 2;
 		f += ddF_x;
 
@@ -560,7 +561,7 @@ void Arduboy2Base::drawLine(int16_t x0, int16_t y0, int16_t x1, int16_t y1, uint
 		ystep = -1;
 	}
 
-	for (; x0 <= x1; x0++)
+	for (; x0 <= x1; ++x0)
 	{
 		if (steep)
 		{
@@ -591,7 +592,7 @@ void Arduboy2Base::drawRect(int16_t x, int16_t y, uint8_t w, uint8_t h, uint8_t 
 void Arduboy2Base::drawFastVLine(int16_t x, int16_t y, uint8_t h, uint8_t color)
 {
 	int end = y+h;
-	for (int a = max(0,y); a < min(end,HEIGHT); a++)
+	for (int a = max(0,y); a < min(end,HEIGHT); ++a)
 		drawPixel(x,a,color);
 }
 
@@ -630,14 +631,22 @@ void Arduboy2Base::drawFastHLine(int16_t x, int16_t y, uint8_t w, uint8_t color)
 	switch (color)
 	{
 		case WHITE:
-			while (w--)
-				*pBuf++ |= mask;
+			while (w)
+			{
+				--w;
+				*pBuf |= mask;
+				++pBuf;
+			}
 			break;
 
 		case BLACK:
 			mask = ~mask;
-			while (w--)
-				*pBuf++ &= mask;
+			while (w)
+			{
+				--w;
+				*pBuf &= mask;
+				++pBuf;
+			}
 			break;
 	}
 }
@@ -645,7 +654,7 @@ void Arduboy2Base::drawFastHLine(int16_t x, int16_t y, uint8_t w, uint8_t color)
 void Arduboy2Base::fillRect(int16_t x, int16_t y, uint8_t w, uint8_t h, uint8_t color)
 {
 	// stupidest version - update in subclasses if desired!
-	for (int16_t i=x; i<x+w; i++)
+	for (int16_t i=x; i<x+w; ++i)
 		drawFastVLine(i, y, h, color);
 }
 
@@ -801,7 +810,7 @@ void Arduboy2Base::fillTriangle(int16_t x0, int16_t y0, int16_t x1, int16_t y1, 
 		last = y1-1;
 
 
-	for(y = y0; y <= last; y++)
+	for(y = y0; y <= last; ++y)
 	{
 		a   = x0 + sa / dy01;
 		b   = x0 + sb / dy02;
@@ -819,7 +828,7 @@ void Arduboy2Base::fillTriangle(int16_t x0, int16_t y0, int16_t x1, int16_t y1, 
 	sa = dx12 * (y - y1);
 	sb = dx02 * (y - y0);
 
-	for(; y <= y2; y++)
+	for(; y <= y2; ++y)
 	{
 		a   = x1 + sa / dy12;
 		b   = x0 + sb / dy02;
@@ -843,20 +852,20 @@ void Arduboy2Base::drawBitmap(int16_t x, int16_t y, const uint8_t *bitmap, uint8
 	int sRow = y / 8;
 	if (y < 0)
 	{
-		sRow--;
+		--sRow;
 		yOffset = 8 - yOffset;
 	}
 	int rows = h/8;
 	if (h%8!=0)
-		rows++;
-	for (int a = 0; a < rows; a++)
+		++rows;
+	for (int a = 0; a < rows; ++a)
 	{
 		int bRow = sRow + a;
 		if (bRow > (HEIGHT/8)-1)
 			break;
 		if (bRow > -2)
 		{
-			for (int iCol = 0; iCol<w; iCol++)
+			for (int iCol = 0; iCol<w; ++iCol)
 			{
 				if (iCol + x > (WIDTH-1))
 					break;
@@ -894,8 +903,8 @@ void Arduboy2Base::drawSlowXYBitmap(int16_t x, int16_t y, const uint8_t *bitmap,
 		return;
 
 	int16_t xi, yi, byteWidth = (w + 7) / 8;
-	for(yi = 0; yi < h; yi++)
-		for(xi = 0; xi < w; xi++ )
+	for(yi = 0; yi < h; ++yi)
+		for(xi = 0; xi < w; ++xi)
 			if(pgm_read_byte(bitmap + yi * byteWidth + xi / 8) & (128 >> (xi & 7)))
 				drawPixel(x + xi, y + yi, color);
 }
@@ -917,7 +926,7 @@ struct BitStreamReader
 	uint16_t readBits(uint16_t bitCount)
 	{
 		uint16_t result = 0;
-		for (uint16_t i = 0; i < bitCount; i++)
+		for (uint16_t i = 0; i < bitCount; ++i)
 		{
 			if (this->bitBuffer == 0)
 			{
@@ -956,7 +965,7 @@ void Arduboy2Base::drawCompressed(int16_t sx, int16_t sy, const uint8_t *bitmap,
 	int startRow = sy / 8;
 	if (sy < 0)
 	{
-		startRow--;
+		--startRow;
 		yOffset = 8 - yOffset;
 	}
 	int rows = height / 8;
@@ -1105,11 +1114,11 @@ uint8_t Arduboy2Base::readUnitName(char* name)
 	uint8_t dest;
 	uint8_t src = EEPROM_UNIT_NAME;
 
-	for (dest = 0; dest < ARDUBOY_UNIT_NAME_LEN; dest++)
+	for (dest = 0; dest < ARDUBOY_UNIT_NAME_LEN; ++dest)
 	{
 		val = EEPROM.read(src);
 		name[dest] = val;
-		src++;
+		++src;
 		if (val == 0x00 || (byte)val == 0xFF)
 			break;
 	}
@@ -1123,13 +1132,13 @@ void Arduboy2Base::writeUnitName(char* name)
 	bool done = false;
 	uint8_t dest = EEPROM_UNIT_NAME;
 
-	for (uint8_t src = 0; src < ARDUBOY_UNIT_NAME_LEN; src++)
+	for (uint8_t src = 0; src < ARDUBOY_UNIT_NAME_LEN; ++src)
 	{
 		if (name[src] == 0x00)
 			done = true;
 		// write character or 0 pad if finished
 		EEPROM.update(dest, done ? 0x00 : name[src]);
-		dest++;
+		++dest;
 	}
 }
 
@@ -1206,7 +1215,7 @@ void Arduboy2::bootLogoText()
 	if (showLEDs)
 		digitalWriteRGB(RED_LED, RGB_ON);
 
-	for (int16_t y = -16; y <= 24; y++)
+	for (int16_t y = -16; y <= 24; ++y)
 	{
 		if (pressed(RIGHT_BUTTON))
 		{
@@ -1309,19 +1318,20 @@ void Arduboy2::drawChar(int16_t x, int16_t y, unsigned char c, uint8_t color, ui
 	if ((x >= WIDTH) || (y >= HEIGHT) || ((x + 5 * size - 1) < 0) || ((y + 8 * size - 1) < 0))
 		return;
 
-	for (uint8_t i = 0; i < 6; i++ )
+	for (uint8_t i = 0; i < 6; ++i)
 	{
-		line = pgm_read_byte(bitmap++);
+		line = pgm_read_byte(bitmap);
+		++bitmap;
 		if (i == 5)
 			line = 0x0;
 
-		for (uint8_t j = 0; j < 8; j++)
+		for (uint8_t j = 0; j < 8; ++j)
 		{
 			uint8_t draw_color = (line & 0x1) ? color : bg;
 
 			if (draw_color || draw_background)
-				for (uint8_t a = 0; a < size; a++ )
-					for (uint8_t b = 0; b < size; b++ )
+				for (uint8_t a = 0; a < size; ++a)
+					for (uint8_t b = 0; b < size; ++b)
 						drawPixel(x + (i * size) + a, y + (j * size) + b, draw_color);
 			line >>= 1;
 		}

--- a/Arduboy2/Arduboy2Beep.cpp
+++ b/Arduboy2/Arduboy2Beep.cpp
@@ -36,9 +36,13 @@ void BeepPin1::tone(uint16_t count, uint8_t dur)
 
 void BeepPin1::timer()
 {
-	if (duration && (--duration == 0))
-		// set normal mode (which disconnects the pin)
-		TCCR3A = 0;
+	if (duration)
+	{
+		--duration;
+		if(duration == 0)
+			// set normal mode (which disconnects the pin)
+			TCCR3A = 0;
+	}
 }
 
 void BeepPin1::noTone()
@@ -85,9 +89,13 @@ void BeepPin2::tone(uint16_t count, uint8_t dur)
 
 void BeepPin2::timer()
 {
-	if (duration && (--duration == 0))
-		// set normal mode (which disconnects the pin)
-		TCCR4A = 0;
+	if (duration)
+	{
+		--duration;
+		if(duration == 0)
+			// set normal mode (which disconnects the pin)
+			TCCR4A = 0;
+	}
 }
 
 void BeepPin2::noTone()

--- a/Arduboy2/Arduboy2Core.cpp
+++ b/Arduboy2/Arduboy2Core.cpp
@@ -210,7 +210,7 @@ void Arduboy2Core::bootOLED()
 	// run our customized boot-up command sequence against the
 	// OLED to initialize it properly for Arduboy
 	LCDCommandMode();
-	for (uint8_t i = 0; i < sizeof(lcdBootProgram); i++)
+	for (uint8_t i = 0; i < sizeof(lcdBootProgram); ++i)
 		SPItransfer(pgm_read_byte(lcdBootProgram + i));
 	LCDDataMode();
 }
@@ -327,7 +327,7 @@ void Arduboy2Core::paint8Pixels(uint8_t pixels)
 
 void Arduboy2Core::paintScreen(const uint8_t *image)
 {
-	for (int i = 0; i < (HEIGHT*WIDTH)/8; i++)
+	for (int i = 0; i < (HEIGHT*WIDTH)/8; ++i)
 		SPItransfer(pgm_read_byte(image + i));
 }
 
@@ -390,10 +390,14 @@ void Arduboy2Core::paintScreen(uint8_t image[], bool clear)
 		// set the first SPI data byte to get things started
 		SPDR = image[i]; 
 		// clear the first image byte
-		image[i++] = 0;  
+		image[i] = 0;  
+		++i;
 	}
 	else
-		SPDR = image[i++];
+	{
+		SPDR = image[i];
+		++i;
+	}
 
 	// the code to iterate the loop and get the next byte from the buffer is
 	// executed while the previous byte is being sent out by the SPI controller
@@ -405,10 +409,14 @@ void Arduboy2Core::paintScreen(uint8_t image[], bool clear)
 		{
 			c = image[i];
 			// clear the byte in the image buffer
-			image[i++] = 0;
+			image[i] = 0;  
+			++i;
 		}
 		else
-			c = image[i++];
+		{
+			c = image[i];
+			++i;
+		}
 
 		// wait for the previous byte to be sent
 		while (!(SPSR & _BV(SPIF)));
@@ -424,7 +432,7 @@ void Arduboy2Core::paintScreen(uint8_t image[], bool clear)
 
 void Arduboy2Core::blank()
 {
-	for (int i = 0; i < (HEIGHT*WIDTH)/8; i++)
+	for (int i = 0; i < (HEIGHT*WIDTH)/8; ++i)
 		SPItransfer(0x00);
 }
 

--- a/Arduboy2/Sprites.cpp
+++ b/Arduboy2/Sprites.cpp
@@ -41,8 +41,9 @@ void Sprites::draw(int16_t x, int16_t y, const uint8_t *bitmap, uint8_t frame, c
 		return;
 
 	uint8_t width = pgm_read_byte(bitmap);
-	uint8_t height = pgm_read_byte(++bitmap);
-	bitmap++;
+	++bitmap;
+	uint8_t height = pgm_read_byte(bitmap);
+	++bitmap;
 	if (frame > 0 || sprite_frame > 0)
 	{
 		frame_offset = (width * ( height / 8 + ( height % 8 == 0 ? 0 : 1)));
@@ -127,9 +128,9 @@ void Sprites::drawBitmap(int16_t x, int16_t y, const uint8_t *bitmap, const uint
 			mask_data = ~(0xFF * mul_amt);
 			// really if yOffset = 0 you have a faster case here that could be
 			// optimized
-			for (uint8_t a = 0; a < loop_h; a++)
+			for (uint8_t a = 0; a < loop_h; ++a)
 			{
-				for (uint8_t iCol = 0; iCol < rendered_width; iCol++)
+				for (uint8_t iCol = 0; iCol < rendered_width; ++iCol)
 				{
 					bitmap_data = pgm_read_byte(bofs) * mul_amt;
 
@@ -147,48 +148,48 @@ void Sprites::drawBitmap(int16_t x, int16_t y, const uint8_t *bitmap, const uint
 						data |= (*((unsigned char *) (&bitmap_data) + 1));
 						Arduboy2Base::sBuffer[ofs + WIDTH] = data;
 					}
-					ofs++;
-					bofs++;
+					++ofs;
+					++bofs;
 				}
-				sRow++;
+				++sRow;
 				bofs += w - rendered_width;
 				ofs += WIDTH - rendered_width;
 			}
 			break;
 
 		case SPRITE_IS_MASK:
-			for (uint8_t a = 0; a < loop_h; a++)
+			for (uint8_t a = 0; a < loop_h; ++a)
 			{
-				for (uint8_t iCol = 0; iCol < rendered_width; iCol++)
+				for (uint8_t iCol = 0; iCol < rendered_width; ++iCol)
 				{
 					bitmap_data = pgm_read_byte(bofs) * mul_amt;
 					if (sRow >= 0)
 						Arduboy2Base::sBuffer[ofs] |= (uint8_t)(bitmap_data);
 					if (yOffset != 0 && sRow < 7)
 						Arduboy2Base::sBuffer[ofs + WIDTH] |= (*((unsigned char *) (&bitmap_data) + 1));
-					ofs++;
-					bofs++;
+					++ofs;
+					++bofs;
 				}
-				sRow++;
+				++sRow;
 				bofs += w - rendered_width;
 				ofs += WIDTH - rendered_width;
 			}
 			break;
 
 		case SPRITE_IS_MASK_ERASE:
-			for (uint8_t a = 0; a < loop_h; a++)
+			for (uint8_t a = 0; a < loop_h; ++a)
 			{
-				for (uint8_t iCol = 0; iCol < rendered_width; iCol++)
+				for (uint8_t iCol = 0; iCol < rendered_width; ++iCol)
 				{
 					bitmap_data = pgm_read_byte(bofs) * mul_amt;
 					if (sRow >= 0)
 						Arduboy2Base::sBuffer[ofs]  &= ~(uint8_t)(bitmap_data);
 					if (yOffset != 0 && sRow < 7)
 						Arduboy2Base::sBuffer[ofs + WIDTH] &= ~(*((unsigned char *) (&bitmap_data) + 1));
-					ofs++;
-					bofs++;
+					++ofs;
+					++bofs;
 				}
-				sRow++;
+				++sRow;
 				bofs += w - rendered_width;
 				ofs += WIDTH - rendered_width;
 			}
@@ -197,9 +198,9 @@ void Sprites::drawBitmap(int16_t x, int16_t y, const uint8_t *bitmap, const uint
 		case SPRITE_MASKED:
 			uint8_t *mask_ofs;
 			mask_ofs = (uint8_t *)mask + (start_h * w) + xOffset;
-			for (uint8_t a = 0; a < loop_h; a++)
+			for (uint8_t a = 0; a < loop_h; ++a)
 			{
-				for (uint8_t iCol = 0; iCol < rendered_width; iCol++)
+				for (uint8_t iCol = 0; iCol < rendered_width; ++iCol)
 				{
 					// NOTE: you might think in the yOffset==0 case that this results
 					// in more effort, but in all my testing the compiler was forcing
@@ -226,11 +227,11 @@ void Sprites::drawBitmap(int16_t x, int16_t y, const uint8_t *bitmap, const uint
 						data |= (*((unsigned char *) (&bitmap_data) + 1));
 						Arduboy2Base::sBuffer[ofs + WIDTH] = data;
 					}
-					ofs++;
-					mask_ofs++;
-					bofs++;
+					++ofs;
+					++mask_ofs;
+					++bofs;
 				}
-				sRow++;
+				++sRow;
 				bofs += w - rendered_width;
 				mask_ofs += w - rendered_width;
 				ofs += WIDTH - rendered_width;

--- a/Arduboy2/SpritesB.cpp
+++ b/Arduboy2/SpritesB.cpp
@@ -42,8 +42,9 @@ void SpritesB::draw(int16_t x, int16_t y, const uint8_t *bitmap, uint8_t frame, 
 		return;
 
 	uint8_t width = pgm_read_byte(bitmap);
-	uint8_t height = pgm_read_byte(++bitmap);
-	bitmap++;
+	++bitmap;
+	uint8_t height = pgm_read_byte(bitmap);
+	++bitmap;
 	if (frame > 0 || sprite_frame > 0)
 	{
 		frame_offset = (width * ( height / 8 + ( height % 8 == 0 ? 0 : 1)));
@@ -126,9 +127,9 @@ void SpritesB::drawBitmap(int16_t x, int16_t y, const uint8_t *bitmap, const uin
 	const uint8_t *mask_ofs = !mask ? bitmap : mask;
 	mask_ofs += initial_bofs + ofs_step - 1;
 
-	for (uint8_t a = 0; a < loop_h; a++)
+	for (uint8_t a = 0; a < loop_h; ++a)
 	{
-		for (uint8_t iCol = 0; iCol < rendered_width; iCol++)
+		for (uint8_t iCol = 0; iCol < rendered_width; ++iCol)
 		{
 			uint8_t data;
 
@@ -156,11 +157,11 @@ void SpritesB::drawBitmap(int16_t x, int16_t y, const uint8_t *bitmap, const uin
 				data |= (*((unsigned char *) (&bitmap_data) + 1));
 				Arduboy2Base::sBuffer[ofs + WIDTH] = data;
 			}
-			ofs++;
+			++ofs;
 			mask_ofs += ofs_step;
 			bofs += ofs_step;
 		}
-		sRow++;
+		++sRow;
 		bofs += ofs_stride;
 		mask_ofs += ofs_stride;
 		ofs += WIDTH - rendered_width;


### PR DESCRIPTION
Replaces postincrements and postdecrements with preincrements and predecrements.
Moves all increments and decrements out of expressions to ensure that expressions don't produce side effects.
If expressions can be assumed to not have side effects then it's easier to reason about the order of operations without having to worry about sequencing issues.