### PR TITLE
Remove unnecessary limits.h include

### DIFF
--- a/Arduboy2/Arduboy2.h
+++ b/Arduboy2/Arduboy2.h
@@ -14,7 +14,6 @@
 #include "Sprites.h"
 #include "SpritesB.h"
 #include <Print.h>
-#include <limits.h>
 
 /** \brief
  * Library version

--- a/Arduboy2/Arduboy2Core.h
+++ b/Arduboy2/Arduboy2Core.h
@@ -11,7 +11,6 @@
 #include <avr/power.h>
 #include <avr/sleep.h>
 #include <avr/wdt.h>
-#include <limits.h>
 
 
 // main hardware compile flags


### PR DESCRIPTION
The contents of `limits.h` aren't actually used anywhere so it's safe to uninclude it.