### PR TITLE
Alter definition of int_farptr_t and uint_farptr_t

### DIFF
--- a/avr-libc/__farptr__.h
+++ b/avr-libc/__farptr__.h
@@ -5,10 +5,12 @@
 //
 
 #include <cstdint>
+#include <type_traits>
 
 //
 // Non-standard type aliases
 //
 
-using int_farptr_t = std::int32_t;
-using uint_farptr_t = std::uint32_t;
+// Ensure that the types are at least 32 bits in length, and large enough to store a pointer
+using int_farptr_t = typename std::conditional<(sizeof(std::intptr_t) >= sizeof(std::int32_t)), std::intptr_t, std::int32_t>::type;
+using uint_farptr_t = typename std::conditional<(sizeof(std::uintptr_t) >= sizeof(std::uint32_t)), std::uintptr_t, std::uint32_t>::type;


### PR DESCRIPTION
Makes them at least 32 bits and guaranteed to be large enough to store a pointer.