### PR TITLE
Add Pokitto::Arduboy2Helper namespace

### DIFF
--- a/Arduboy2/PokittoHelper.cpp
+++ b/Arduboy2/PokittoHelper.cpp
@@ -1,0 +1,14 @@
+#pragma once
+
+#include "PokittoHelper.h"
+
+#include <Pokitto.h>
+
+namespace Pokitto
+{
+	namespace Arduboy2Helper
+	{		
+		static constexpr std::size_t BaseX = (220 / 2) - (Width / 2);
+		static constexpr std::size_t BaseY = (176 / 2) - (Height / 2);
+	};
+}

--- a/Arduboy2/PokittoHelper.h
+++ b/Arduboy2/PokittoHelper.h
@@ -1,0 +1,14 @@
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+
+namespace Pokitto
+{
+	namespace Arduboy2Helper
+	{
+		static constexpr std::size_t Width = 128;
+		static constexpr std::size_t Height = 64;
+		static constexpr std::size_t BufferSize = (Width * Height) / 8;
+	};
+}


### PR DESCRIPTION
Adds a namespace to keep the helper functions and 'glue code'.