### PR TITLE
Fix colour inversion bug

### DIFF
--- a/Arduboy2/Arduboy2.h
+++ b/Arduboy2/Arduboy2.h
@@ -15,6 +15,11 @@
 #include "SpritesB.h"
 #include <Print.h>
 
+// Include Pokitto early to let it define BLACK and WHITE,
+// then we can overwrite them later on to the values Arduboy2 needs
+#define DISABLEAVRMIN
+#include <Pokitto.h>
+
 /** \brief
  * Library version
  *


### PR DESCRIPTION
The bug was caused by the Gamebuino compatibility layer defining BLACK as 1 and WHITE as 0.
Arduboy2 requires BLACK to be defined as 0 and WHITE to be defined as 1.
The solution is to force the PokittoLib to define the Gamebuino compatibility layer before Arduboy2 defines BLACK and WHITE,
thus allowing Arduboy2 to overwrite the Gamebuino definitions.