### PR TITLE
Prevent flicker by using screen persistence

### DIFF
--- a/Arduino/main.cpp
+++ b/Arduino/main.cpp
@@ -48,6 +48,7 @@ int main(void)
 
 	// Pharap: Add Pokitto::Core::begin() call
 	Pokitto::Core::begin();
+	Pokitto::Display::persistence = static_cast<std::uint8_t>(~0);
 	
 	setup();
 


### PR DESCRIPTION
Prevents flickering by enabling Pokitto screen persistence.
I.e. prevent the Pokitto from clearing its display buffer each frame.