### PR TITLE
Fix halting bug in Sprites and SpritesB

### DIFF
--- a/Arduboy2/Sprites.cpp
+++ b/Arduboy2/Sprites.cpp
@@ -133,10 +133,11 @@ void Sprites::drawBitmap(int16_t x, int16_t y, const uint8_t * bitmap, const uin
 
 					if(yOffset != 0 && sRow < 7)
 					{
-						uint8_t data = Arduboy2Base::sBuffer[ofs + WIDTH];
+						const std::size_t index = static_cast<uint16_t>(ofs + WIDTH);
+						uint8_t data = Arduboy2Base::sBuffer[index];
 						data &= (reinterpret_cast<const unsigned char *>(&mask_data)[1]);
 						data |= (reinterpret_cast<const unsigned char *>(&bitmap_data)[1]);
-						Arduboy2Base::sBuffer[ofs + WIDTH] = data;
+						Arduboy2Base::sBuffer[index] = data;
 					}
 
 					++ofs;
@@ -187,7 +188,10 @@ void Sprites::drawBitmap(int16_t x, int16_t y, const uint8_t * bitmap, const uin
 						Arduboy2Base::sBuffer[ofs]  &= ~static_cast<uint8_t>(bitmap_data);
 
 					if(yOffset != 0 && sRow < 7)
-						Arduboy2Base::sBuffer[ofs + WIDTH] &= ~(reinterpret_cast<const unsigned char *>(&bitmap_data)[1]);
+					{
+						const std::size_t index = static_cast<uint16_t>(ofs + WIDTH);
+						Arduboy2Base::sBuffer[index] &= ~(reinterpret_cast<const unsigned char *>(&bitmap_data)[1]);
+					}
 
 					++ofs;
 					++bofs;
@@ -229,10 +233,11 @@ void Sprites::drawBitmap(int16_t x, int16_t y, const uint8_t * bitmap, const uin
 
 					if(yOffset != 0 && sRow < 7)
 					{
-						uint8_t data = Arduboy2Base::sBuffer[ofs + WIDTH];
+						const std::size_t index = static_cast<uint16_t>(ofs + WIDTH);
+						uint8_t data = Arduboy2Base::sBuffer[index];
 						data &= (reinterpret_cast<const unsigned char *>(&mask_data)[1]);
 						data |= (reinterpret_cast<const unsigned char *>(&bitmap_data)[1]);
-						Arduboy2Base::sBuffer[ofs + WIDTH] = data;
+						Arduboy2Base::sBuffer[index] = data;
 					}
 
 					++ofs;

--- a/Arduboy2/SpritesB.cpp
+++ b/Arduboy2/SpritesB.cpp
@@ -141,10 +141,11 @@ void SpritesB::drawBitmap(int16_t x, int16_t y, const uint8_t * bitmap, const ui
 
 			if(yOffset != 0 && sRow < 7)
 			{
-				uint8_t data = Arduboy2Base::sBuffer[ofs + WIDTH];
+				const std::size_t index = static_cast<uint16_t>(ofs + WIDTH);
+				uint8_t data = Arduboy2Base::sBuffer[index];
 				data &= (reinterpret_cast<const unsigned char *>(&mask_data)[1]);
 				data |= (reinterpret_cast<const unsigned char *>(&bitmap_data)[1]);
-				Arduboy2Base::sBuffer[ofs + WIDTH] = data;
+				Arduboy2Base::sBuffer[index] = data;
 			}
 
 			++ofs;


### PR DESCRIPTION
The bug was causing the whole processor to freeze.
After a long investigation I discovered that the freezing was due to a buffer overrun.
The buffer overrun was in turn caused by the difference in size between Pokitto's int and Arduboy's int.
The original code was relying on Arduboy's 16 bit int type to overflow without propagating the overflow bit.
With the Pokitto's 32 bit int the overflow bit was retained and the result was a number large enough to cause a buffer overrun when indexing Arduboy2's screen buffer.