### PR TITLE
Implement EEPROM functionality

### DIFF
--- a/avr-libc/avr/eeprom.cpp
+++ b/avr-libc/avr/eeprom.cpp
@@ -110,10 +110,5 @@ void eeprom_update_float(float * pointer, float value)
 
 void eeprom_update_block(const void * source, void * destination, size_t count)
 {
-	(void)destination;
-	(void)source;
-	(void)count;
-
-	// TODO: Implement eeprom_update_block(const void * source, void * destination, size_t count)
-    //writeEEPROM((std::uint16_t *)source, (std::uint8_t *)destination, count);
+	writeEEPROM(const_cast<std::uint16_t *>(reinterpret_cast<const std::uint16_t *>(destination)), const_cast<std::uint8_t *>(reinterpret_cast<const std::uint8_t *>(source)), count);
 }

--- a/avr-libc/avr/eeprom.cpp
+++ b/avr-libc/avr/eeprom.cpp
@@ -68,11 +68,7 @@ void eeprom_write_dword(std::uint32_t * pointer, std::uint32_t value)
 
 void eeprom_write_float(float * pointer, float value)
 {
-	(void)pointer;
-	(void)value;
-
-	// TODO: Implement eeprom_write_float(float * pointer, float value)
-    //writeEEPROM(const_cast<std::uint16_t *>(reinterpret_cast<const std::uint16_t *>(pointer)), const_cast<std::uint8_t *>(reinterpret_cast<const std::uint8_t *>(&value)), sizeof(float));
+	writeEEPROM(const_cast<std::uint16_t *>(reinterpret_cast<const std::uint16_t *>(pointer)), const_cast<std::uint8_t *>(reinterpret_cast<const std::uint8_t *>(&value)), sizeof(float));
 }
 
 void eeprom_write_block(const void * source, void * destination, size_t count)

--- a/avr-libc/avr/eeprom.cpp
+++ b/avr-libc/avr/eeprom.cpp
@@ -82,13 +82,9 @@ void eeprom_write_block(const void * source, void * destination, size_t count)
 
 void eeprom_update_byte(std::uint8_t * pointer, std::uint8_t value)
 {
-	(void)pointer;
-	(void)value;
-
-	// TODO: Implement eeprom_update_byte(std::uint8_t * pointer, std::uint8_t value)
-	//auto current = eeprom_read_byte(pointer);
-	//if(current != value)
-		//writeEEPROM(const_cast<std::uint16_t *>(reinterpret_cast<const std::uint16_t *>(pointer)), const_cast<std::uint8_t *>(reinterpret_cast<const std::uint8_t *>(&value)), sizeof(std::uint8_t));
+	auto current = eeprom_read_byte(pointer);
+	if(current != value)
+		writeEEPROM(const_cast<std::uint16_t *>(reinterpret_cast<const std::uint16_t *>(pointer)), const_cast<std::uint8_t *>(reinterpret_cast<const std::uint8_t *>(&value)), sizeof(std::uint8_t));
 }
 
 void eeprom_update_word(std::uint16_t * pointer, std::uint16_t value)

--- a/avr-libc/avr/eeprom.cpp
+++ b/avr-libc/avr/eeprom.cpp
@@ -58,11 +58,7 @@ void eeprom_write_byte(std::uint8_t * pointer, std::uint8_t value)
 
 void eeprom_write_word(std::uint16_t * pointer, std::uint16_t value)
 {
-	(void)pointer;
-	(void)value;
-
-	// TODO: Implement eeprom_write_word(std::uint16_t * pointer, std::uint16_t value)
-    //writeEEPROM(const_cast<std::uint16_t *>(reinterpret_cast<const std::uint16_t *>(pointer)), const_cast<std::uint8_t *>(reinterpret_cast<const std::uint8_t *>(&value)), sizeof(std::uint16_t));
+	writeEEPROM(const_cast<std::uint16_t *>(reinterpret_cast<const std::uint16_t *>(pointer)), const_cast<std::uint8_t *>(reinterpret_cast<const std::uint8_t *>(&value)), sizeof(std::uint16_t));
 }
 
 void eeprom_write_dword(std::uint32_t * pointer, std::uint32_t value)

--- a/avr-libc/avr/eeprom.cpp
+++ b/avr-libc/avr/eeprom.cpp
@@ -13,7 +13,7 @@
 // __ATTR_PURE__
 std::uint8_t eeprom_read_byte(const std::uint8_t * pointer)
 {
-	std::uint8_t value = ~0;
+	std::uint8_t value = 0;
 	readEEPROM(const_cast<std::uint16_t *>(reinterpret_cast<const std::uint16_t *>(pointer)), reinterpret_cast<std::uint8_t *>(&value), sizeof(std::uint8_t));
 	return value;
 }
@@ -21,7 +21,7 @@ std::uint8_t eeprom_read_byte(const std::uint8_t * pointer)
 // __ATTR_PURE__
 std::uint16_t eeprom_read_word(const std::uint16_t * pointer)
 {
-	std::uint16_t value = ~0;
+	std::uint16_t value = 0;
 	readEEPROM(const_cast<std::uint16_t *>(reinterpret_cast<const std::uint16_t *>(pointer)), reinterpret_cast<std::uint8_t *>(&value), sizeof(std::uint16_t));
 	return value;
 }
@@ -29,7 +29,7 @@ std::uint16_t eeprom_read_word(const std::uint16_t * pointer)
 // __ATTR_PURE__
 std::uint32_t eeprom_read_dword(const std::uint32_t * pointer)
 {
-	std::uint32_t value = ~0;
+	std::uint32_t value = 0;
 	readEEPROM(const_cast<std::uint16_t *>(reinterpret_cast<const std::uint16_t *>(pointer)), reinterpret_cast<std::uint8_t *>(&value), sizeof(std::uint32_t));
 	return value;
 }
@@ -37,7 +37,7 @@ std::uint32_t eeprom_read_dword(const std::uint32_t * pointer)
 // __ATTR_PURE__
 float eeprom_read_float(const float * pointer)
 {
-	float value = ~0;
+	float value = 0;
 	readEEPROM(const_cast<std::uint16_t *>(reinterpret_cast<const std::uint16_t *>(pointer)), reinterpret_cast<std::uint8_t *>(&value), sizeof(float));
 	return value;
 }

--- a/avr-libc/avr/eeprom.cpp
+++ b/avr-libc/avr/eeprom.cpp
@@ -13,11 +13,8 @@
 // __ATTR_PURE__
 std::uint8_t eeprom_read_byte(const std::uint8_t * pointer)
 {
-	(void)pointer;
-	
-    std::uint8_t value = ~0;
-	// TODO: Implement eeprom_read_byte(const std::uint8_t * pointer)
-    //readEEPROM(const_cast<std::uint16_t *>(reinterpret_cast<const std::uint16_t *>(pointer)), const_cast<std::uint8_t *>(reinterpret_cast<const std::uint8_t *>(&value)), sizeof(std::uint8_t));
+	std::uint8_t value = ~0;
+	readEEPROM(const_cast<std::uint16_t *>(reinterpret_cast<const std::uint16_t *>(pointer)), const_cast<std::uint8_t *>(reinterpret_cast<const std::uint8_t *>(&value)), sizeof(std::uint8_t));
 	return value;
 }
 

--- a/avr-libc/avr/eeprom.cpp
+++ b/avr-libc/avr/eeprom.cpp
@@ -44,12 +44,7 @@ float eeprom_read_float(const float * pointer)
 
 void eeprom_read_block(void * destination, const void * source, size_t count)
 {
-	(void)destination;
-	(void)source;
-	(void)count;
-	
-	// TODO: Implement eeprom_read_block(void * destination, const void * source, size_t count)
-    //readEEPROM((std::uint16_t *)source, (std::uint8_t *)destination, count);
+	readEEPROM(const_cast<std::uint16_t *>(reinterpret_cast<const std::uint16_t *>(source)), const_cast<std::uint8_t *>(reinterpret_cast<const std::uint8_t *>(destination)), count);
 }
 
 //

--- a/avr-libc/avr/eeprom.cpp
+++ b/avr-libc/avr/eeprom.cpp
@@ -96,13 +96,9 @@ void eeprom_update_word(std::uint16_t * pointer, std::uint16_t value)
 
 void eeprom_update_dword(std::uint32_t * pointer, std::uint32_t value)
 {
-	(void)pointer;
-	(void)value;
-
-	// TODO: Implement eeprom_update_dword(std::uint32_t * pointer, std::uint32_t value)
-	//auto current = eeprom_read_dword(pointer);
-	//if(current != value)
-		//writeEEPROM(const_cast<std::uint16_t *>(reinterpret_cast<const std::uint16_t *>(pointer)), const_cast<std::uint8_t *>(reinterpret_cast<const std::uint8_t *>(&value)), sizeof(std::uint32_t));
+	auto current = eeprom_read_dword(pointer);
+	if(current != value)
+		writeEEPROM(const_cast<std::uint16_t *>(reinterpret_cast<const std::uint16_t *>(pointer)), const_cast<std::uint8_t *>(reinterpret_cast<const std::uint8_t *>(&value)), sizeof(std::uint32_t));
 }
 
 void eeprom_update_float(float * pointer, float value)

--- a/avr-libc/avr/eeprom.cpp
+++ b/avr-libc/avr/eeprom.cpp
@@ -37,11 +37,8 @@ std::uint32_t eeprom_read_dword(const std::uint32_t * pointer)
 // __ATTR_PURE__
 float eeprom_read_float(const float * pointer)
 {
-	(void)pointer;
-	
-    float value = ~0;
-	// TODO: Implement eeprom_read_float(const float * pointer)
-    //readEEPROM(const_cast<std::uint16_t *>(reinterpret_cast<const std::uint16_t *>(pointer)), const_cast<std::uint8_t *>(reinterpret_cast<const std::uint8_t *>(&value)), sizeof(float));
+	float value = ~0;
+	readEEPROM(const_cast<std::uint16_t *>(reinterpret_cast<const std::uint16_t *>(pointer)), const_cast<std::uint8_t *>(reinterpret_cast<const std::uint8_t *>(&value)), sizeof(float));
 	return value;
 }
 

--- a/avr-libc/avr/eeprom.cpp
+++ b/avr-libc/avr/eeprom.cpp
@@ -63,11 +63,7 @@ void eeprom_write_word(std::uint16_t * pointer, std::uint16_t value)
 
 void eeprom_write_dword(std::uint32_t * pointer, std::uint32_t value)
 {
-	(void)pointer;
-	(void)value;
-
-	// TODO: Implement eeprom_write_dword(std::uint32_t * pointer, std::uint32_t value)
-    //writeEEPROM(const_cast<std::uint16_t *>(reinterpret_cast<const std::uint16_t *>(pointer)), const_cast<std::uint8_t *>(reinterpret_cast<const std::uint8_t *>(&value)), sizeof(std::uint32_t));
+	writeEEPROM(const_cast<std::uint16_t *>(reinterpret_cast<const std::uint16_t *>(pointer)), const_cast<std::uint8_t *>(reinterpret_cast<const std::uint8_t *>(&value)), sizeof(std::uint32_t));
 }
 
 void eeprom_write_float(float * pointer, float value)

--- a/avr-libc/avr/eeprom.cpp
+++ b/avr-libc/avr/eeprom.cpp
@@ -29,11 +29,8 @@ std::uint16_t eeprom_read_word(const std::uint16_t * pointer)
 // __ATTR_PURE__
 std::uint32_t eeprom_read_dword(const std::uint32_t * pointer)
 {
-	(void)pointer;
-	
-    std::uint32_t value = ~0;
-	// TODO: Implement eeprom_read_dword(const std::uint32_t * pointer)
-    //readEEPROM(const_cast<std::uint16_t *>(reinterpret_cast<const std::uint16_t *>(pointer)), const_cast<std::uint8_t *>(reinterpret_cast<const std::uint8_t *>(&value)), sizeof(std::uint32_t));
+	std::uint32_t value = ~0;
+	readEEPROM(const_cast<std::uint16_t *>(reinterpret_cast<const std::uint16_t *>(pointer)), const_cast<std::uint8_t *>(reinterpret_cast<const std::uint8_t *>(&value)), sizeof(std::uint32_t));
 	return value;
 }
 

--- a/avr-libc/avr/eeprom.cpp
+++ b/avr-libc/avr/eeprom.cpp
@@ -53,11 +53,7 @@ void eeprom_read_block(void * destination, const void * source, size_t count)
 
 void eeprom_write_byte(std::uint8_t * pointer, std::uint8_t value)
 {
-	(void)pointer;
-	(void)value;
-
-	// TODO: Implement eeprom_write_byte(std::uint8_t * pointer, std::uint8_t value)
-    //writeEEPROM(const_cast<std::uint16_t *>(reinterpret_cast<const std::uint16_t *>(pointer)), const_cast<std::uint8_t *>(reinterpret_cast<const std::uint8_t *>(&value)), sizeof(std::uint8_t));
+	writeEEPROM(const_cast<std::uint16_t *>(reinterpret_cast<const std::uint16_t *>(pointer)), const_cast<std::uint8_t *>(reinterpret_cast<const std::uint8_t *>(&value)), sizeof(std::uint8_t));
 }
 
 void eeprom_write_word(std::uint16_t * pointer, std::uint16_t value)

--- a/avr-libc/avr/eeprom.cpp
+++ b/avr-libc/avr/eeprom.cpp
@@ -21,11 +21,8 @@ std::uint8_t eeprom_read_byte(const std::uint8_t * pointer)
 // __ATTR_PURE__
 std::uint16_t eeprom_read_word(const std::uint16_t * pointer)
 {
-	(void)pointer;
-	
-    std::uint16_t value = ~0;
-	// TODO: Implement eeprom_read_word(const std::uint16_t * pointer)
-    //readEEPROM(const_cast<std::uint16_t *>(reinterpret_cast<const std::uint16_t *>(pointer)), const_cast<std::uint8_t *>(reinterpret_cast<const std::uint8_t *>(&value)), sizeof(std::uint16_t));
+	std::uint16_t value = ~0;
+	readEEPROM(const_cast<std::uint16_t *>(reinterpret_cast<const std::uint16_t *>(pointer)), const_cast<std::uint8_t *>(reinterpret_cast<const std::uint8_t *>(&value)), sizeof(std::uint16_t));
 	return value;
 }
 

--- a/avr-libc/avr/eeprom.cpp
+++ b/avr-libc/avr/eeprom.cpp
@@ -73,12 +73,7 @@ void eeprom_write_float(float * pointer, float value)
 
 void eeprom_write_block(const void * source, void * destination, size_t count)
 {
-	(void)destination;
-	(void)source;
-	(void)count;
-	
-	// TODO: Implement eeprom_write_block(const void * source, void * destination, size_t count)
-    //writeEEPROM((std::uint16_t *)source, (std::uint8_t *)destination, count);
+	writeEEPROM(const_cast<std::uint16_t *>(reinterpret_cast<const std::uint16_t *>(destination)), const_cast<std::uint8_t *>(reinterpret_cast<const std::uint8_t *>(source)), count);
 }
 
 //

--- a/avr-libc/avr/eeprom.cpp
+++ b/avr-libc/avr/eeprom.cpp
@@ -89,13 +89,9 @@ void eeprom_update_byte(std::uint8_t * pointer, std::uint8_t value)
 
 void eeprom_update_word(std::uint16_t * pointer, std::uint16_t value)
 {
-	(void)pointer;
-	(void)value;
-
-	// TODO: Implement eeprom_update_word(std::uint16_t * pointer, std::uint16_t value)
-	//auto current = eeprom_read_word(pointer);
-	//if(current != value)
-		//writeEEPROM(const_cast<std::uint16_t *>(reinterpret_cast<const std::uint16_t *>(pointer)), const_cast<std::uint8_t *>(reinterpret_cast<const std::uint8_t *>(&value)), sizeof(std::uint16_t));
+	auto current = eeprom_read_word(pointer);
+	if(current != value)
+		writeEEPROM(const_cast<std::uint16_t *>(reinterpret_cast<const std::uint16_t *>(pointer)), const_cast<std::uint8_t *>(reinterpret_cast<const std::uint8_t *>(&value)), sizeof(std::uint16_t));
 }
 
 void eeprom_update_dword(std::uint32_t * pointer, std::uint32_t value)

--- a/avr-libc/avr/eeprom.cpp
+++ b/avr-libc/avr/eeprom.cpp
@@ -103,13 +103,9 @@ void eeprom_update_dword(std::uint32_t * pointer, std::uint32_t value)
 
 void eeprom_update_float(float * pointer, float value)
 {
-	(void)pointer;
-	(void)value;
-
-	// TODO: Implement eeprom_update_float(float * pointer, float value)
-	//auto current = eeprom_read_float(pointer);
-	//if(current != value)
-		//writeEEPROM(const_cast<std::uint16_t *>(reinterpret_cast<const std::uint16_t *>(pointer)), const_cast<std::uint8_t *>(reinterpret_cast<const std::uint8_t *>(&value)), sizeof(float));
+	auto current = eeprom_read_float(pointer);
+	if(current != value)
+		writeEEPROM(const_cast<std::uint16_t *>(reinterpret_cast<const std::uint16_t *>(pointer)), const_cast<std::uint8_t *>(reinterpret_cast<const std::uint8_t *>(&value)), sizeof(float));
 }
 
 void eeprom_update_block(const void * source, void * destination, size_t count)

--- a/avr-libc/avr/eeprom.cpp
+++ b/avr-libc/avr/eeprom.cpp
@@ -14,7 +14,7 @@
 std::uint8_t eeprom_read_byte(const std::uint8_t * pointer)
 {
 	std::uint8_t value = ~0;
-	readEEPROM(const_cast<std::uint16_t *>(reinterpret_cast<const std::uint16_t *>(pointer)), const_cast<std::uint8_t *>(reinterpret_cast<const std::uint8_t *>(&value)), sizeof(std::uint8_t));
+	readEEPROM(const_cast<std::uint16_t *>(reinterpret_cast<const std::uint16_t *>(pointer)), reinterpret_cast<std::uint8_t *>(&value), sizeof(std::uint8_t));
 	return value;
 }
 
@@ -22,7 +22,7 @@ std::uint8_t eeprom_read_byte(const std::uint8_t * pointer)
 std::uint16_t eeprom_read_word(const std::uint16_t * pointer)
 {
 	std::uint16_t value = ~0;
-	readEEPROM(const_cast<std::uint16_t *>(reinterpret_cast<const std::uint16_t *>(pointer)), const_cast<std::uint8_t *>(reinterpret_cast<const std::uint8_t *>(&value)), sizeof(std::uint16_t));
+	readEEPROM(const_cast<std::uint16_t *>(reinterpret_cast<const std::uint16_t *>(pointer)), reinterpret_cast<std::uint8_t *>(&value), sizeof(std::uint16_t));
 	return value;
 }
 
@@ -30,7 +30,7 @@ std::uint16_t eeprom_read_word(const std::uint16_t * pointer)
 std::uint32_t eeprom_read_dword(const std::uint32_t * pointer)
 {
 	std::uint32_t value = ~0;
-	readEEPROM(const_cast<std::uint16_t *>(reinterpret_cast<const std::uint16_t *>(pointer)), const_cast<std::uint8_t *>(reinterpret_cast<const std::uint8_t *>(&value)), sizeof(std::uint32_t));
+	readEEPROM(const_cast<std::uint16_t *>(reinterpret_cast<const std::uint16_t *>(pointer)), reinterpret_cast<std::uint8_t *>(&value), sizeof(std::uint32_t));
 	return value;
 }
 
@@ -38,13 +38,13 @@ std::uint32_t eeprom_read_dword(const std::uint32_t * pointer)
 float eeprom_read_float(const float * pointer)
 {
 	float value = ~0;
-	readEEPROM(const_cast<std::uint16_t *>(reinterpret_cast<const std::uint16_t *>(pointer)), const_cast<std::uint8_t *>(reinterpret_cast<const std::uint8_t *>(&value)), sizeof(float));
+	readEEPROM(const_cast<std::uint16_t *>(reinterpret_cast<const std::uint16_t *>(pointer)), reinterpret_cast<std::uint8_t *>(&value), sizeof(float));
 	return value;
 }
 
 void eeprom_read_block(void * destination, const void * source, size_t count)
 {
-	readEEPROM(const_cast<std::uint16_t *>(reinterpret_cast<const std::uint16_t *>(source)), const_cast<std::uint8_t *>(reinterpret_cast<const std::uint8_t *>(destination)), count);
+	readEEPROM(const_cast<std::uint16_t *>(reinterpret_cast<const std::uint16_t *>(source)), reinterpret_cast<std::uint8_t *>(destination), count);
 }
 
 //
@@ -53,27 +53,27 @@ void eeprom_read_block(void * destination, const void * source, size_t count)
 
 void eeprom_write_byte(std::uint8_t * pointer, std::uint8_t value)
 {
-	writeEEPROM(const_cast<std::uint16_t *>(reinterpret_cast<const std::uint16_t *>(pointer)), const_cast<std::uint8_t *>(reinterpret_cast<const std::uint8_t *>(&value)), sizeof(std::uint8_t));
+	writeEEPROM(reinterpret_cast<std::uint16_t *>(pointer), reinterpret_cast<std::uint8_t *>(&value), sizeof(std::uint8_t));
 }
 
 void eeprom_write_word(std::uint16_t * pointer, std::uint16_t value)
 {
-	writeEEPROM(const_cast<std::uint16_t *>(reinterpret_cast<const std::uint16_t *>(pointer)), const_cast<std::uint8_t *>(reinterpret_cast<const std::uint8_t *>(&value)), sizeof(std::uint16_t));
+	writeEEPROM(reinterpret_cast<std::uint16_t *>(pointer), reinterpret_cast<std::uint8_t *>(&value), sizeof(std::uint16_t));
 }
 
 void eeprom_write_dword(std::uint32_t * pointer, std::uint32_t value)
 {
-	writeEEPROM(const_cast<std::uint16_t *>(reinterpret_cast<const std::uint16_t *>(pointer)), const_cast<std::uint8_t *>(reinterpret_cast<const std::uint8_t *>(&value)), sizeof(std::uint32_t));
+	writeEEPROM(reinterpret_cast<std::uint16_t *>(pointer), reinterpret_cast<std::uint8_t *>(&value), sizeof(std::uint32_t));
 }
 
 void eeprom_write_float(float * pointer, float value)
 {
-	writeEEPROM(const_cast<std::uint16_t *>(reinterpret_cast<const std::uint16_t *>(pointer)), const_cast<std::uint8_t *>(reinterpret_cast<const std::uint8_t *>(&value)), sizeof(float));
+	writeEEPROM(reinterpret_cast<std::uint16_t *>(pointer), reinterpret_cast<std::uint8_t *>(&value), sizeof(float));
 }
 
 void eeprom_write_block(const void * source, void * destination, size_t count)
 {
-	writeEEPROM(const_cast<std::uint16_t *>(reinterpret_cast<const std::uint16_t *>(destination)), const_cast<std::uint8_t *>(reinterpret_cast<const std::uint8_t *>(source)), count);
+	writeEEPROM(reinterpret_cast<std::uint16_t *>(destination), const_cast<std::uint8_t *>(reinterpret_cast<const std::uint8_t *>(source)), count);
 }
 
 //
@@ -84,31 +84,31 @@ void eeprom_update_byte(std::uint8_t * pointer, std::uint8_t value)
 {
 	auto current = eeprom_read_byte(pointer);
 	if(current != value)
-		writeEEPROM(const_cast<std::uint16_t *>(reinterpret_cast<const std::uint16_t *>(pointer)), const_cast<std::uint8_t *>(reinterpret_cast<const std::uint8_t *>(&value)), sizeof(std::uint8_t));
+		writeEEPROM(reinterpret_cast<std::uint16_t *>(pointer), reinterpret_cast<std::uint8_t *>(&value), sizeof(std::uint8_t));
 }
 
 void eeprom_update_word(std::uint16_t * pointer, std::uint16_t value)
 {
 	auto current = eeprom_read_word(pointer);
 	if(current != value)
-		writeEEPROM(const_cast<std::uint16_t *>(reinterpret_cast<const std::uint16_t *>(pointer)), const_cast<std::uint8_t *>(reinterpret_cast<const std::uint8_t *>(&value)), sizeof(std::uint16_t));
+		writeEEPROM(reinterpret_cast<std::uint16_t *>(pointer), reinterpret_cast<std::uint8_t *>(&value), sizeof(std::uint16_t));
 }
 
 void eeprom_update_dword(std::uint32_t * pointer, std::uint32_t value)
 {
 	auto current = eeprom_read_dword(pointer);
 	if(current != value)
-		writeEEPROM(const_cast<std::uint16_t *>(reinterpret_cast<const std::uint16_t *>(pointer)), const_cast<std::uint8_t *>(reinterpret_cast<const std::uint8_t *>(&value)), sizeof(std::uint32_t));
+		writeEEPROM(reinterpret_cast<std::uint16_t *>(pointer), reinterpret_cast<std::uint8_t *>(&value), sizeof(std::uint32_t));
 }
 
 void eeprom_update_float(float * pointer, float value)
 {
 	auto current = eeprom_read_float(pointer);
 	if(current != value)
-		writeEEPROM(const_cast<std::uint16_t *>(reinterpret_cast<const std::uint16_t *>(pointer)), const_cast<std::uint8_t *>(reinterpret_cast<const std::uint8_t *>(&value)), sizeof(float));
+		writeEEPROM(reinterpret_cast<std::uint16_t *>(pointer), reinterpret_cast<std::uint8_t *>(&value), sizeof(float));
 }
 
 void eeprom_update_block(const void * source, void * destination, size_t count)
 {
-	writeEEPROM(const_cast<std::uint16_t *>(reinterpret_cast<const std::uint16_t *>(destination)), const_cast<std::uint8_t *>(reinterpret_cast<const std::uint8_t *>(source)), count);
+	writeEEPROM(reinterpret_cast<std::uint16_t *>(destination), const_cast<std::uint8_t *>(reinterpret_cast<const std::uint8_t *>(source)), count);
 }

--- a/avr-libc/avr/eeprom.cpp
+++ b/avr-libc/avr/eeprom.cpp
@@ -4,7 +4,7 @@
 // Includes
 //
 
-//#include <Pokitto.h>
+#include <Pokitto.h>
 
 //
 // EEPROM read functions
@@ -15,9 +15,9 @@ std::uint8_t eeprom_read_byte(const std::uint8_t * pointer)
 {
 	(void)pointer;
 	
-	std::uint8_t value = ~0;
+    std::uint8_t value = ~0;
 	// TODO: Implement eeprom_read_byte(const std::uint8_t * pointer)
-	//readEEPROM(const_cast<std::uint16_t *>(reinterpret_cast<const std::uint16_t *>(pointer)), const_cast<std::uint8_t *>(reinterpret_cast<const std::uint8_t *>(&value)), sizeof(std::uint8_t));
+    //readEEPROM(const_cast<std::uint16_t *>(reinterpret_cast<const std::uint16_t *>(pointer)), const_cast<std::uint8_t *>(reinterpret_cast<const std::uint8_t *>(&value)), sizeof(std::uint8_t));
 	return value;
 }
 
@@ -26,9 +26,9 @@ std::uint16_t eeprom_read_word(const std::uint16_t * pointer)
 {
 	(void)pointer;
 	
-	std::uint16_t value = ~0;
+    std::uint16_t value = ~0;
 	// TODO: Implement eeprom_read_word(const std::uint16_t * pointer)
-	//readEEPROM(const_cast<std::uint16_t *>(reinterpret_cast<const std::uint16_t *>(pointer)), const_cast<std::uint8_t *>(reinterpret_cast<const std::uint8_t *>(&value)), sizeof(std::uint16_t));
+    //readEEPROM(const_cast<std::uint16_t *>(reinterpret_cast<const std::uint16_t *>(pointer)), const_cast<std::uint8_t *>(reinterpret_cast<const std::uint8_t *>(&value)), sizeof(std::uint16_t));
 	return value;
 }
 
@@ -37,9 +37,9 @@ std::uint32_t eeprom_read_dword(const std::uint32_t * pointer)
 {
 	(void)pointer;
 	
-	std::uint32_t value = ~0;
+    std::uint32_t value = ~0;
 	// TODO: Implement eeprom_read_dword(const std::uint32_t * pointer)
-	//readEEPROM(const_cast<std::uint16_t *>(reinterpret_cast<const std::uint16_t *>(pointer)), const_cast<std::uint8_t *>(reinterpret_cast<const std::uint8_t *>(&value)), sizeof(std::uint32_t));
+    //readEEPROM(const_cast<std::uint16_t *>(reinterpret_cast<const std::uint16_t *>(pointer)), const_cast<std::uint8_t *>(reinterpret_cast<const std::uint8_t *>(&value)), sizeof(std::uint32_t));
 	return value;
 }
 
@@ -48,9 +48,9 @@ float eeprom_read_float(const float * pointer)
 {
 	(void)pointer;
 	
-	float value = ~0;
+    float value = ~0;
 	// TODO: Implement eeprom_read_float(const float * pointer)
-	//readEEPROM(const_cast<std::uint16_t *>(reinterpret_cast<const std::uint16_t *>(pointer)), const_cast<std::uint8_t *>(reinterpret_cast<const std::uint8_t *>(&value)), sizeof(float));
+    //readEEPROM(const_cast<std::uint16_t *>(reinterpret_cast<const std::uint16_t *>(pointer)), const_cast<std::uint8_t *>(reinterpret_cast<const std::uint8_t *>(&value)), sizeof(float));
 	return value;
 }
 
@@ -61,7 +61,7 @@ void eeprom_read_block(void * destination, const void * source, size_t count)
 	(void)count;
 	
 	// TODO: Implement eeprom_read_block(void * destination, const void * source, size_t count)
-	//readEEPROM((std::uint16_t *)source, (std::uint8_t *)destination, count);
+    //readEEPROM((std::uint16_t *)source, (std::uint8_t *)destination, count);
 }
 
 //
@@ -74,7 +74,7 @@ void eeprom_write_byte(std::uint8_t * pointer, std::uint8_t value)
 	(void)value;
 
 	// TODO: Implement eeprom_write_byte(std::uint8_t * pointer, std::uint8_t value)
-	//writeEEPROM(const_cast<std::uint16_t *>(reinterpret_cast<const std::uint16_t *>(pointer)), const_cast<std::uint8_t *>(reinterpret_cast<const std::uint8_t *>(&value)), sizeof(std::uint8_t));
+    //writeEEPROM(const_cast<std::uint16_t *>(reinterpret_cast<const std::uint16_t *>(pointer)), const_cast<std::uint8_t *>(reinterpret_cast<const std::uint8_t *>(&value)), sizeof(std::uint8_t));
 }
 
 void eeprom_write_word(std::uint16_t * pointer, std::uint16_t value)
@@ -83,7 +83,7 @@ void eeprom_write_word(std::uint16_t * pointer, std::uint16_t value)
 	(void)value;
 
 	// TODO: Implement eeprom_write_word(std::uint16_t * pointer, std::uint16_t value)
-	//writeEEPROM(const_cast<std::uint16_t *>(reinterpret_cast<const std::uint16_t *>(pointer)), const_cast<std::uint8_t *>(reinterpret_cast<const std::uint8_t *>(&value)), sizeof(std::uint16_t));
+    //writeEEPROM(const_cast<std::uint16_t *>(reinterpret_cast<const std::uint16_t *>(pointer)), const_cast<std::uint8_t *>(reinterpret_cast<const std::uint8_t *>(&value)), sizeof(std::uint16_t));
 }
 
 void eeprom_write_dword(std::uint32_t * pointer, std::uint32_t value)
@@ -92,7 +92,7 @@ void eeprom_write_dword(std::uint32_t * pointer, std::uint32_t value)
 	(void)value;
 
 	// TODO: Implement eeprom_write_dword(std::uint32_t * pointer, std::uint32_t value)
-	//writeEEPROM(const_cast<std::uint16_t *>(reinterpret_cast<const std::uint16_t *>(pointer)), const_cast<std::uint8_t *>(reinterpret_cast<const std::uint8_t *>(&value)), sizeof(std::uint32_t));
+    //writeEEPROM(const_cast<std::uint16_t *>(reinterpret_cast<const std::uint16_t *>(pointer)), const_cast<std::uint8_t *>(reinterpret_cast<const std::uint8_t *>(&value)), sizeof(std::uint32_t));
 }
 
 void eeprom_write_float(float * pointer, float value)
@@ -101,7 +101,7 @@ void eeprom_write_float(float * pointer, float value)
 	(void)value;
 
 	// TODO: Implement eeprom_write_float(float * pointer, float value)
-	//writeEEPROM(const_cast<std::uint16_t *>(reinterpret_cast<const std::uint16_t *>(pointer)), const_cast<std::uint8_t *>(reinterpret_cast<const std::uint8_t *>(&value)), sizeof(float));
+    //writeEEPROM(const_cast<std::uint16_t *>(reinterpret_cast<const std::uint16_t *>(pointer)), const_cast<std::uint8_t *>(reinterpret_cast<const std::uint8_t *>(&value)), sizeof(float));
 }
 
 void eeprom_write_block(const void * source, void * destination, size_t count)
@@ -111,7 +111,7 @@ void eeprom_write_block(const void * source, void * destination, size_t count)
 	(void)count;
 	
 	// TODO: Implement eeprom_write_block(const void * source, void * destination, size_t count)
-	//writeEEPROM((std::uint16_t *)source, (std::uint8_t *)destination, count);
+    //writeEEPROM((std::uint16_t *)source, (std::uint8_t *)destination, count);
 }
 
 //
@@ -169,5 +169,5 @@ void eeprom_update_block(const void * source, void * destination, size_t count)
 	(void)count;
 
 	// TODO: Implement eeprom_update_block(const void * source, void * destination, size_t count)
-	//writeEEPROM((std::uint16_t *)source, (std::uint8_t *)destination, count);
+    //writeEEPROM((std::uint16_t *)source, (std::uint8_t *)destination, count);
 }


### PR DESCRIPTION
There may be better ways to implement these functions in future,
but doing so would probably require some changes to the Pokitto library.
For now these implementations will suffice as they are effectively functional,
and all bar `eeprom_update_block` are functionally equivalent.