### PR TITLE
Rename Arduboy2Helper to ArduboyUtilities

### DIFF
--- a/Arduboy2/Arduboy2Core.cpp
+++ b/Arduboy2/Arduboy2Core.cpp
@@ -230,7 +230,7 @@ void Arduboy2Core::paint8Pixels(uint8_t pixels)
 
 void Arduboy2Core::paintScreen(const uint8_t * image)
 {
-	using namespace Pokitto::Arduboy2Helper;
+	using namespace Pokitto::ArduboyUtilities;
 	Display::drawBuffer(image);
 	Display::update();
 }
@@ -243,14 +243,14 @@ void Arduboy2Core::paintScreen(const uint8_t * image)
 // It is specifically tuned for a 16MHz CPU clock and SPI clocking at 8MHz.
 void Arduboy2Core::paintScreen(uint8_t image[], bool clear)
 {
-	using namespace Pokitto::Arduboy2Helper;
+	using namespace Pokitto::ArduboyUtilities;
 	Display::drawBuffer(image, clear);
 	Display::update();
 }
 
 void Arduboy2Core::blank(void)
 {
-	using namespace Pokitto::Arduboy2Helper;
+	using namespace Pokitto::ArduboyUtilities;
 	Display::fillDisplay(0);
 	Display::update();
 }

--- a/Arduboy2/PokittoHelper.cpp
+++ b/Arduboy2/PokittoHelper.cpp
@@ -6,7 +6,7 @@
 
 namespace Pokitto
 {
-	namespace Arduboy2Helper
+	namespace ArduboyUtilities
 	{
 		constexpr std::size_t PokittoDisplayWidth = LCDWIDTH;
 		constexpr std::size_t PokittoDisplayHeight = LCDHEIGHT;

--- a/Arduboy2/PokittoHelper.h
+++ b/Arduboy2/PokittoHelper.h
@@ -7,7 +7,7 @@
 
 namespace Pokitto
 {
-	namespace Arduboy2Helper
+	namespace ArduboyUtilities
 	{
 		constexpr std::size_t BitsPerByte = 8;
 


### PR DESCRIPTION
Renames the Pokitto::Arduboy2Helper namespace to Pokitto::ArduboyUtilities.