### PR TITLE
Use static void casts

### DIFF
--- a/Arduboy2/Arduboy2Beep.cpp
+++ b/Arduboy2/Arduboy2Beep.cpp
@@ -161,7 +161,7 @@ void BeepPin1::tone(uint16_t count)
 void BeepPin1::tone(uint16_t count, uint8_t dur)
 {
 	// Intentionally unused
-	(void)count;
+	static_cast<void>(count);
 
 	duration = dur;
 }
@@ -194,7 +194,7 @@ void BeepPin2::tone(uint16_t count)
 void BeepPin2::tone(uint16_t count, uint8_t dur)
 {
 	// Intentionally unused
-	(void)count;
+	static_cast<void>(count);
 
 	duration = dur;
 }

--- a/Arduboy2/Arduboy2Core.cpp
+++ b/Arduboy2/Arduboy2Core.cpp
@@ -155,7 +155,7 @@ void Arduboy2Core::bootSPI()
 void Arduboy2Core::SPItransfer(uint8_t data)
 {
 	// Arduboy2Core::SPItransfer(uint8_t data) is intentionally unimplemented.
-	(void)data;
+	static_cast<void>(data);
 }
 
 void Arduboy2Core::safeMode()
@@ -306,17 +306,17 @@ void Arduboy2Core::setRGBled(uint8_t red, uint8_t green, uint8_t blue)
 {
 	// TODO: Investigate the best way to implement Arduboy2Core::setRGBled(uint8_t red, uint8_t green, uint8_t blue)
 
-	(void)red;
-	(void)green;
-	(void)blue;
+	static_cast<void>(red);
+	static_cast<void>(green);
+	static_cast<void>(blue);
 }
 
 void Arduboy2Core::setRGBled(uint8_t color, uint8_t val)
 {
 	// TODO: Investigate the best way to implement Arduboy2Core::setRGBled(uint8_t color, uint8_t val)
 
-	(void)color;
-	(void)val;
+	static_cast<void>(color);
+	static_cast<void>(val);
 }
 
 void Arduboy2Core::freeRGBled()
@@ -328,17 +328,17 @@ void Arduboy2Core::digitalWriteRGB(uint8_t red, uint8_t green, uint8_t blue)
 {
 	// TODO: Investigate the best way to implement Arduboy2Core::digitalWriteRGB(uint8_t red, uint8_t green, uint8_t blue)
 
-	(void)red;
-	(void)green;
-	(void)blue;
+	static_cast<void>(red);
+	static_cast<void>(green);
+	static_cast<void>(blue);
 }
 
 void Arduboy2Core::digitalWriteRGB(uint8_t color, uint8_t val)
 {
 	// TODO: Investigate the best way to implement Arduboy2Core::digitalWriteRGB(uint8_t color, uint8_t val)
 
-	(void)color;
-	(void)val;
+	static_cast<void>(color);
+	static_cast<void>(val);
 }
 
 /* Buttons */

--- a/avr-libc/stdlib.cpp
+++ b/avr-libc/stdlib.cpp
@@ -107,9 +107,9 @@ char * ultoa(unsigned long value, char * str, int radix)
 
 char * dtostrf(double value, signed char width, unsigned char precision, char * str)
 {
-	(void)value;
-	(void)width;
-	(void)precision;
+	static_cast<void>(value);
+	static_cast<void>(width);
+	static_cast<void>(precision);
 	
 	// TODO: implement dtostrf(double value, signed char width, unsigned char precision, char * str)
 	return str;
@@ -117,8 +117,8 @@ char * dtostrf(double value, signed char width, unsigned char precision, char * 
 
 //char * dtostre(double value, char * str, unsigned char precision, unsigned char flags)
 //{
-//	(void)value;
-//	(void)radix;
+//	static_cast<void>(value);
+//	static_cast<void>(radix);
 //	
 //	// TODO: implement dtostre(double value, char * str, unsigned char precision, unsigned char flags)
 //	return str;


### PR DESCRIPTION
When I originally wrote these I didn't realise that `static_cast<void>` could be used instead of C-style casting.